### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Xenonesis/Budget-Buddy/security/code-scanning/1](https://github.com/Xenonesis/Budget-Buddy/security/code-scanning/1)

To fix this vulnerability, add a `permissions` block to the workflow YAML at the root level. This block should restrict permissions for all jobs (unless overridden within individual jobs). Given the tasks performed (checking out code, running tests, publishing to npm), only `contents: read` is required.  
Specifically, insert:

```yaml
permissions:
  contents: read
```

after the `name:` key (line 4), before the `on:` key (line 6). No other changes are required; both jobs will inherit these minimal permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
