### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -6,13 +6,22 @@ export function middleware(request: NextRequest) {
     const url = request.nextUrl.searchParams.get('url');
     
     // Block problematic external image URLs
-    if (url && (
-      url.includes('images.unsplash.com') ||
-      url.includes('photo-1494790108755-2616b612b786')
-    )) {
-      // Return a 1x1 transparent pixel instead of attempting to fetch
-      const transparentPixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-      return NextResponse.redirect(transparentPixel);
+    if (url) {
+      try {
+        const parsedUrl = new URL(url);
+        // Block if host is exactly 'images.unsplash.com'
+        if (
+          parsedUrl.hostname === 'images.unsplash.com' ||
+          parsedUrl.pathname.includes('photo-1494790108755-2616b612b786')
+        ) {
+        const transparentPixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        return NextResponse.redirect(transparentPixel);
+      }
+      } catch (e) {
+        // If URL is invalid, optionally block or ignore. We'll block:
+        const transparentPixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        return NextResponse.redirect(transparentPixel);
+      }
     }
   }
   


### PR DESCRIPTION
Potential fix for [https://github.com/Xenonesis/Budget-Buddy/security/code-scanning/3](https://github.com/Xenonesis/Budget-Buddy/security/code-scanning/3)

To properly secure the sanitization, the URL must be parsed and the host checked explicitly, not via substring. The `url` string should be parsed as a URL object (using the standard `URL` constructor in JavaScript/TypeScript), and then the `host` (or `hostname`) property compared against a whitelist of allowed hosts (e.g., `'images.unsplash.com'`). Checking the exact host prevents attackers from bypassing the filter by embedding the allowed host in other URL components.

**Specifically:**
- Use the `URL` constructor to parse the supplied `url` parameter.
- Catch any parsing errors (in case of invalid URLs).
- Ensure that the comparison is performed only on the `hostname` (or, rarely, `host`, but `hostname` is usually proper).
- Replace the substring-based check (`url.includes(...)`) with an array inclusion check: e.g., `allowedHosts.includes(parsed.hostname)`.
- Update code in lines 10 and 11 of `middleware.ts` as required.

If blocking a specific path (like the second check: `'photo-1494790108755-2616b612b786'`), you may want to check the pathname of the parsed URL as well.

**Required:**
- No new libraries needed (can use built-in `URL`).
- Optionally, handle parsing errors gracefully (URL constructor will throw if the url is invalid).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
