### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/components/ui/team.tsx
+++ b/components/ui/team.tsx
@@ -79,7 +79,14 @@ export default function TeamSection() {
                                                 onError={(e) => {
                                                     // Fallback to a placeholder if image fails to load
                                                     const target = e.currentTarget;
-                                                    if (!target.src.includes('ui-avatars.com')) {
+                                                    let isUiAvatarHost = false;
+                                                    try {
+                                                        const host = new URL(target.src).hostname;
+                                                        isUiAvatarHost = (host === 'ui-avatars.com');
+                                                    } catch (err) {
+                                                        // If parsing fails, treat host as not ui-avatars.com
+                                                    }
+                                                    if (!isUiAvatarHost) {
                                                         target.src = `https://ui-avatars.com/api/?name=${encodeURIComponent(member.name)}&background=6366f1&color=fff&size=200&bold=true`;
                                                     }
                                                 }}


### PR DESCRIPTION
Potential fix for [https://github.com/Xenonesis/Budget-Buddy/security/code-scanning/4](https://github.com/Xenonesis/Budget-Buddy/security/code-scanning/4)

To fix this problem, we should parse the URL using the browser-native `URL` class and check the hostname instead of using a substring search. This ensures that only images with an actual host of `ui-avatars.com` are considered valid. The change is to replace the line:
```js
if (!target.src.includes('ui-avatars.com')) {
```
with:
```js
try {
  const host = new URL(target.src).hostname;
  if (host !== 'ui-avatars.com') {
    // fallback logic
  }
} catch (e) {
  // fallback logic
}
```
We may need to handle exceptions in case `target.src` is not a valid URL. We'll add this change to the `onError` handler in the `<img>` block inside the `components/ui/team.tsx` file. No new imports are needed, as `URL` is natively supported in browsers and Node.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
