### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/components/ui/team.tsx
+++ b/components/ui/team.tsx
@@ -79,7 +79,13 @@ export default function TeamSection() {
                                                 onError={(e) => {
                                                     // Fallback to a placeholder if image fails to load
                                                     const target = e.currentTarget;
-                                                    if (!target.src.includes('ui-avatars.com')) {
+                                                    try {
+                                                        const url = new URL(target.src);
+                                                        if (url.hostname !== 'ui-avatars.com') {
+                                                            target.src = `https://ui-avatars.com/api/?name=${encodeURIComponent(member.name)}&background=6366f1&color=fff&size=200&bold=true`;
+                                                        }
+                                                    } catch (error) {
+                                                        // If the URL constructor fails, fall back to setting the default
                                                         target.src = `https://ui-avatars.com/api/?name=${encodeURIComponent(member.name)}&background=6366f1&color=fff&size=200&bold=true`;
                                                     }
                                                 }}


### PR DESCRIPTION
Potential fix for [https://github.com/Xenonesis/Budget-Buddy/security/code-scanning/4](https://github.com/Xenonesis/Budget-Buddy/security/code-scanning/4)

To fix the problem, the code should parse the URL and check if the hostname is exactly `'ui-avatars.com'` (or matches an allowed list of hosts). The fix involves replacing the substring check on line 82 with a more robust check: parsing `target.src` using the built-in `URL` class and comparing `.hostname` with `'ui-avatars.com'`. No change in intended fallback functionality will occur, but the check is now precise. The relevant code change is in components/ui/team.tsx, specifically the `onError` handler in the `<img ... />` element. No new dependencies are needed, as the WHATWG `URL` class is globally available in modern browsers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
